### PR TITLE
add `comma-dangle` with option "always-multiline"

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,7 @@
     "arrow-spacing": "error",
     "brace-style": ["error", "stroustrup", { "allowSingleLine": true }],
     "camelcase": ["error", { "properties": "never" }],
+    "comma-dangle": ["error", "always-multiline"],
     "comma-spacing": "error",
     "comma-style": ["error", "last"],
     "curly": "error",


### PR DESCRIPTION
http://eslint.org/docs/rules/comma-dangle

`always-multiline`

Examples of incorrect code for this rule with the "always-multiline" option:

``` js
/*eslint comma-dangle: ["error", "always-multiline"]*/

var foo = {
    bar: "baz",
    qux: "quux"
};

var foo = { bar: "baz", qux: "quux", };

var arr = [1,2,];

var arr = [1,
    2,];

var arr = [
    1,
    2
];

foo({
  bar: "baz",
  qux: "quux"
});
```

Examples of correct code for this rule with the "always-multiline" option:

``` js
/*eslint comma-dangle: ["error", "always-multiline"]*/

var foo = {
    bar: "baz",
    qux: "quux",
};

var foo = {bar: "baz", qux: "quux"};
var arr = [1,2];

var arr = [1,
    2];

var arr = [
    1,
    2,
];

foo({
  bar: "baz",
  qux: "quux",
});
```
