### PR TITLE
add `object-shorthand`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -50,6 +50,7 @@
     "no-use-before-define": "error",
     "no-with": "error",
     "object-curly-spacing": ["error", "always"],
+    "object-shorthand": ["error", "always"],
     "one-var": ["error", "never"],
     "padded-blocks": ["error", "never"],
     "quote-props": ["error", "as-needed"],


### PR DESCRIPTION
http://eslint.org/docs/rules/object-shorthand, and autofixable

Each of the following properties would warn:

```js
/*eslint object-shorthand: "error"*/
/*eslint-env es6*/

var foo = {
    w: function() {},
    x: function *() {},
    [y]: function() {},
    z: z
};
```

In that case the expected syntax would have been:

```js
/*eslint object-shorthand: "error"*/
/*eslint-env es6*/

var foo = {
    w() {},
    *x() {},
    [y]() {},
    z
};
```