### PR TITLE
add `rest-spread-spacing` never

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -54,6 +54,7 @@
     "padded-blocks": ["error", "never"],
     "quote-props": ["error", "as-needed"],
     "quotes": ["error", "single", "avoid-escape"],
+    "rest-spread-spacing": ["error", "never"],
     "semi": "error",
     "semi-spacing": "error",
     "space-before-blocks": "error",


### PR DESCRIPTION
Examples of incorrect code for this rule with "never":

```
/*eslint rest-spread-spacing: ["error", "never"]*/

fn(... args)
[... arr, 4, 5, 6]
let [a, b, ... arr] = [1, 2, 3, 4, 5];
function fn(... args) { console.log(args); }
let { x, y, ... z } = { x: 1, y: 2, a: 3, b: 4 };
let n = { x, y, ... z };
```

Examples of correct code for this rule with "never":

```

/*eslint rest-spread-spacing: ["error", "never"]*/

fn(...args)
[...arr, 4, 5, 6]
let [a, b, ...arr] = [1, 2, 3, 4, 5];
function fn(...args) { console.log(args); }
let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 };
let n = { x, y, ...z };
```
